### PR TITLE
Add Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+/*
+ *  Typings for jss-preset-default v4.3.0
+ */
+import { JSSOptions } from "jss";
+
+/**
+ * Options object for the defaultUnits: each key is a CSS property,
+ * with the value the corresponding default unit for that property.
+ */
+export type DefaultUnitPluginOptions = {
+    [cssProperty: string]: string;
+}
+
+export type PresetPluginOptions = Partial<{
+    template: {},
+    global: {},
+    extend: {},
+    nested: {},
+    compose: {},
+    camelCase: {},
+    defaultUnit: DefaultUnitPluginOptions,
+    expand: {},
+    vendorPrefixer: {},
+    propsSort: {},
+}>
+
+/**
+ * Build the plugins included in this preset.  Accepts options for each plugin
+ */
+export default function preset(
+    options?: PresetPluginOptions
+): Pick<JSSOptions, "plugins">

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "license": "MIT",
   "main": "./lib/index.js",
+  "typings": "./index.d.ts",
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
@@ -48,6 +49,7 @@
     "jss": "^9.7.0"
   },
   "dependencies": {
+    "@types/jss": "^9.3.1",
     "jss-camel-case": "^6.1.0",
     "jss-compose": "^5.0.0",
     "jss-default-unit": "^8.0.2",


### PR DESCRIPTION
This adds basic typings for this package, which makes it easier to work with in Typescript projects.

These typings don't exist in the DefinitelyTyped repo, and I'm pretty sure it's best practice to include the types directly with the repository, where possible, nowadays:

* No need for users to add an additional dependency (`@types/jss-preset-default`) to their library
* Avoids some versioning issues with having a separate package for typings
* Some editors (VSCode at least) will use bundled typings to improve intellisense, even for JS projects.  